### PR TITLE
Feat: 회원가입 기능 완성

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
   "htmlWhitespaceSensitivity": "css",
   "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
-  "printWidth": 250,
+  "printWidth": 100,
   "proseWrap": "preserve",
   "quoteProps": "as-needed",
   "semi": true,
@@ -17,4 +17,4 @@
   "rangeStart": 0,
   "requirePragma": false,
   "insertPragma": false
-  }
+}

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -1,9 +1,10 @@
 import { Form, FormInstance, Input, message } from 'antd';
 import { FirebaseError } from 'firebase/app';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
-import { addDoc, collection } from 'firebase/firestore';
+import { addDoc, collection, getDocs, query, where } from 'firebase/firestore';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
 import { ReactElement, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { auth, db, storage } from '../../firebase/firebaseConfig';
 import * as St from './style';
 
@@ -19,6 +20,8 @@ const SignUpForm = (): ReactElement => {
   const [form] = Form.useForm();
   const [error, setError] = useState<string | null>(null);
   const [emailError, setEmailError] = useState<string | null>(null);
+
+  const navigate = useNavigate();
 
   const onSubmit = async (values: unknown) => {
     const data = values as SignUpFormData;
@@ -56,6 +59,7 @@ const SignUpForm = (): ReactElement => {
 
       message.success('회원가입이 성공적으로 처리되었습니다');
       setError(null);
+      navigate('/');
     } catch (err) {
       if (err instanceof FirebaseError) {
         if (err.code === 'auth/email-already-in-use') {
@@ -88,11 +92,41 @@ const SignUpForm = (): ReactElement => {
     },
   });
 
+  const checkNicknameDuplication = async (nickname: string): Promise<boolean> => {
+    const querySnapshot = await getDocs(
+      query(collection(db, 'users'), where('displayName', '==', nickname)),
+    );
+    return !querySnapshot.empty;
+  };
+
+  const nicknameValidator = {
+    validator: async (_: unknown, value: string) => {
+      if (!value) {
+        return Promise.resolve();
+      }
+      const isDuplicated = await checkNicknameDuplication(value);
+      if (isDuplicated) {
+        return Promise.reject(new Error('이미 존재하는 닉네임입니다. 다른 닉네임을 입력해주세요.'));
+      }
+      return Promise.resolve();
+    },
+  };
+
   return (
     <St.SignUpFormContainer>
-      <St.SignUpForm form={form} onFinish={onSubmit} name="validateOnly" layout="vertical" autoComplete="off">
-        <Form.Item label="프로필 이미지" name="profileImage" rules={[{ required: true, message: '이미지를 업로드해주세요.' }]}>
-          <Input type="file" id="profileImage" />
+      <St.SignUpForm
+        form={form}
+        onFinish={onSubmit}
+        name="validateOnly"
+        layout="vertical"
+        autoComplete="off"
+      >
+        <Form.Item
+          label="프로필 이미지"
+          name="profileImage"
+          rules={[{ required: true, message: '이미지를 업로드해주세요.' }]}
+        >
+          <St.CustomFileInput type="file" id="profileImage" />
         </Form.Item>
 
         <Form.Item
@@ -108,15 +142,34 @@ const SignUpForm = (): ReactElement => {
           <Input type="email" id="email" onChange={() => setEmailError(null)} />
         </Form.Item>
 
-        <Form.Item label="비밀번호" name="password" rules={[{ required: true, message: '비밀번호를 입력해주세요.' }, passwordValidator()]}>
+        <Form.Item
+          label="비밀번호"
+          name="password"
+          rules={[{ required: true, message: '비밀번호를 입력해주세요.' }, passwordValidator()]}
+        >
           <Input type="password" id="password" />
         </Form.Item>
 
-        <Form.Item label="비밀번호 확인" name="confirmPassword" rules={[{ required: true, message: '비밀번호를 한 번 더 입력해주세요.' }, confirmPasswordValidator(form)]}>
+        <Form.Item
+          label="비밀번호 확인"
+          name="confirmPassword"
+          rules={[
+            { required: true, message: '비밀번호를 한 번 더 입력해주세요.' },
+            confirmPasswordValidator(form),
+          ]}
+        >
           <Input type="password" id="confirmPassword" />
         </Form.Item>
 
-        <Form.Item label="닉네임" name="nickname" rules={[{ required: true, message: '닉네임을 입력해주세요.' }]}>
+        <Form.Item
+          label="닉네임"
+          name="nickname"
+          rules={[
+            { required: true, message: '닉네임을 입력해주세요.' },
+            { min: 2, max: 6, message: '닉네임은 2~6글자로 제한됩니다.' },
+            nicknameValidator,
+          ]}
+        >
           <Input type="text" id="nickname" />
         </Form.Item>
         {error && <p>{error}</p>}
@@ -125,6 +178,10 @@ const SignUpForm = (): ReactElement => {
             회원가입
           </St.Button>
         </St.ButtonContainer>
+        <St.NavigateToSignInContainer>
+          이미 회원이신가요?{' '}
+          <St.SignInText onClick={() => navigate('/signin')}>로그인으로 이동</St.SignInText>
+        </St.NavigateToSignInContainer>
       </St.SignUpForm>
     </St.SignUpFormContainer>
   );

--- a/src/components/SignUp/SignUpForm.tsx
+++ b/src/components/SignUp/SignUpForm.tsx
@@ -1,44 +1,60 @@
-import { Button, Form, Input } from 'antd';
+import { Form, FormInstance, Input, message } from 'antd';
 import { FirebaseError } from 'firebase/app';
 import { createUserWithEmailAndPassword, updateProfile } from 'firebase/auth';
+import { addDoc, collection } from 'firebase/firestore';
 import { getDownloadURL, ref, uploadBytes } from 'firebase/storage';
-import { useState } from 'react';
-import { auth, storage } from '../../firebase/firebaseConfig';
+import { ReactElement, useState } from 'react';
+import { auth, db, storage } from '../../firebase/firebaseConfig';
 import * as St from './style';
 
 type SignUpFormData = {
-  profileImage: FileList;
+  profileImage: File[];
   email: string;
   password: string;
   confirmPassword: string;
   nickname: string;
 };
 
-const SignUpForm = () => {
+const SignUpForm = (): ReactElement => {
+  const [form] = Form.useForm();
   const [error, setError] = useState<string | null>(null);
   const [emailError, setEmailError] = useState<string | null>(null);
 
-  const onSubmit = async (data: SignUpFormData) => {
+  const onSubmit = async (values: unknown) => {
+    const data = values as SignUpFormData;
     try {
       const userCredential = await createUserWithEmailAndPassword(auth, data.email, data.password);
       const { user } = userCredential;
 
-      if (user && data.profileImage.length > 0) {
-        const filePath = `profiles/${user.uid}/profile_picture`;
-        const imageRef = ref(storage, filePath);
-        const file = data.profileImage[0];
-
-        await uploadBytes(imageRef, file);
-        const downloadURL = await getDownloadURL(imageRef);
-
-        await updateProfile(user, {
+      if (user) {
+        const userData = {
+          uid: user.uid,
+          email: data.email,
           displayName: data.nickname,
-          photoURL: downloadURL,
-        });
+          photoURL: '',
+        };
+
+        if (data.profileImage.length > 0) {
+          const filePath = `profiles/${user.uid}/profile_picture`;
+          const imageRef = ref(storage, filePath);
+          const file = data.profileImage[0];
+
+          await uploadBytes(imageRef, file);
+          const downloadURL = await getDownloadURL(imageRef);
+
+          await updateProfile(user, {
+            displayName: data.nickname,
+            photoURL: downloadURL,
+          });
+
+          userData.photoURL = downloadURL; // 이미지 다운로드 URL을 데이터에 추가
+        }
+
+        // 파이어스토어 'users' 컬렉션에 데이터 추가
+        await addDoc(collection(db, 'users'), userData);
       }
-      // 알럿으로 바꾸기
-      alert('회원가입이 성공적으로 처리되었습니다');
-      console.log('회원가입 성공:', userCredential);
+
+      message.success('회원가입이 성공적으로 처리되었습니다');
       setError(null);
     } catch (err) {
       if (err instanceof FirebaseError) {
@@ -63,18 +79,18 @@ const SignUpForm = () => {
     },
   });
 
-  // const confirmPasswordValidator = (formInstance: FormInstance) => ({
-  //   validator(_: unknown, value: string) {
-  //     if (!value || formInstance.getFieldValue('password') === value) {
-  //       return Promise.resolve();
-  //     }
-  //     return Promise.reject(new Error('비밀번호가 일치하지 않습니다.'));
-  //   },
-  // });
+  const confirmPasswordValidator = (formInstance: FormInstance) => ({
+    validator(_: unknown, value: string) {
+      if (!value || formInstance.getFieldValue('password') === value) {
+        return Promise.resolve();
+      }
+      return Promise.reject(new Error('비밀번호가 일치하지 않습니다.'));
+    },
+  });
 
   return (
     <St.SignUpFormContainer>
-      <Form onFinish={onSubmit}>
+      <St.SignUpForm form={form} onFinish={onSubmit} name="validateOnly" layout="vertical" autoComplete="off">
         <Form.Item label="프로필 이미지" name="profileImage" rules={[{ required: true, message: '이미지를 업로드해주세요.' }]}>
           <Input type="file" id="profileImage" />
         </Form.Item>
@@ -96,21 +112,7 @@ const SignUpForm = () => {
           <Input type="password" id="password" />
         </Form.Item>
 
-        <Form.Item
-          label="비밀번호 확인"
-          name="confirmPassword"
-          rules={[
-            { required: true, message: '비밀번호를 한 번 더 입력해주세요.' },
-            ({ getFieldValue }) => ({
-              validator(_, value) {
-                if (!value || getFieldValue('password') === value) {
-                  return Promise.resolve();
-                }
-                return Promise.reject(new Error('비밀번호가 일치하지 않습니다.'));
-              },
-            }),
-          ]}
-        >
+        <Form.Item label="비밀번호 확인" name="confirmPassword" rules={[{ required: true, message: '비밀번호를 한 번 더 입력해주세요.' }, confirmPasswordValidator(form)]}>
           <Input type="password" id="confirmPassword" />
         </Form.Item>
 
@@ -118,12 +120,12 @@ const SignUpForm = () => {
           <Input type="text" id="nickname" />
         </Form.Item>
         {error && <p>{error}</p>}
-        <Form.Item>
-          <Button type="primary" htmlType="submit">
+        <St.ButtonContainer>
+          <St.Button type="default" htmlType="submit">
             회원가입
-          </Button>
-        </Form.Item>
-      </Form>
+          </St.Button>
+        </St.ButtonContainer>
+      </St.SignUpForm>
     </St.SignUpFormContainer>
   );
 };

--- a/src/components/SignUp/style.ts
+++ b/src/components/SignUp/style.ts
@@ -35,3 +35,41 @@ export const Button = styled(AntdButton)`
     color: #ffffff;
   }
 `;
+
+export const CustomFileInput = styled.input`
+  &::-webkit-file-upload-button {
+    cursor: pointer;
+    border: none;
+    border-radius: 5px;
+    padding: 5px 10px;
+    color: #ffffff;
+    background-color: #9acdde;
+    transition: background-color 0.3s;
+
+    &:hover {
+      background-color: #b8e3e8;
+    }
+    &:active {
+      background-color: #67bed0;
+    }
+  }
+`;
+
+export const NavigateToSignInContainer = styled.div`
+  margin-top: 10px;
+  text-align: right;
+`;
+
+export const SignInText = styled.span`
+  color: #9acdde;
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    color: #b8e3e8;
+  }
+
+  &:active {
+    color: #67bed0;
+  }
+`;

--- a/src/components/SignUp/style.ts
+++ b/src/components/SignUp/style.ts
@@ -1,4 +1,4 @@
-import { Form as AntdForm } from 'antd';
+import { Button as AntdButton, Form as AntdForm } from 'antd';
 import { styled } from 'styled-components';
 
 export const SignUpFormContainer = styled.div`
@@ -10,4 +10,28 @@ export const SignUpFormContainer = styled.div`
 
 export const SignUpForm = styled(AntdForm)`
   width: 50%;
+`;
+
+export const ButtonContainer = styled(AntdForm.Item)`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const Button = styled(AntdButton)`
+  background-color: #9acdde;
+  border-color: transparent;
+  color: #ffffff;
+  transition: background-color 0.3s, color 0.3s, border-color 0.3s;
+
+  &:hover {
+    background-color: #b8e3e8;
+    border-color: transparent;
+    color: #ffffff;
+  }
+
+  &:active {
+    background-color: #67bed0;
+    border-color: transparent;
+    color: #ffffff;
+  }
 `;

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,4 +1,4 @@
-import SignUpForm from '../components/SignUp/SignUpForm';
+import SignUpForm from '../components/signUp/SignUpForm';
 
 const SignUp = () => {
   return <SignUpForm />;


### PR DESCRIPTION
Feat: 회원가입 기능 완성
---

1. 회원가입 성공과 동시에 유저정보 auth와 firestore에 각각 저장
2. form css 수정. 모든 input 길이 동일하게.
3. 회원가입 버튼 색상 수정. 프로젝트 테마컬러(블루 : #9acdde)로 변경
4. 프로필 이미지 입력창 변경
5. 닉네임 입력조건 및 중복 검사 추가
6. 로그인 페이지 이동 기능 추가 ("이미 회원이신가요? 로그인으로 이동")

+그 외)
prettierrc파일의 printWidth 250->100으로 수정
SignUpForm 폴더명 SignUp으로 생성한 부분 ->signUp 으로 변경

보완할 사항)
이미지 업로드 시 미리보기

*dev에서 pull 받은 후 PR 했습니다*